### PR TITLE
Fix/sign in

### DIFF
--- a/partials/memberpanel.hbs
+++ b/partials/memberpanel.hbs
@@ -27,8 +27,6 @@
 				<i class="material-icons">login</i>
 			{{else}}
 				<a class="gh-head-button" href="#/portal/signup" data-portal="signup">Subscribe</a>
-				<span class="member-signup"><a href="{{@site.url}}/signup">Subscribe</a></span>
-				<i class="material-icons">mail_outline</i>
 			{{/if}}
 		</div>
 	</div>

--- a/partials/memberpanel.hbs
+++ b/partials/memberpanel.hbs
@@ -26,7 +26,7 @@
 				<span class="member-signup"><a href="{{@site.url}}/account">Account</a></span>
 				<i class="material-icons">login</i>
 			{{else}}
-				<span class="member-singin"><a href="{{@site.url}}/signin">Sign in</a></span>
+				<a class="gh-head-button" href="#/portal/signup" data-portal="signup">Subscribe</a>
 				<span class="member-signup"><a href="{{@site.url}}/signup">Subscribe</a></span>
 				<i class="material-icons">mail_outline</i>
 			{{/if}}


### PR DESCRIPTION
Fix _Sign in_ button which was previously redirecting to a `/signin` page, and it now seems it's using a client side modal (`#portal`) in Ghost v5