### PR TITLE
chore(package.json): bumping version number to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
     "name": "pacific",
     "description": "Grid-based photoblog theme",
-    "version": "2.1.0",
+    "version": "3.0.0",
 	"keywords": ["ghost-theme"],
     "engines": {
-        "ghost": ">=3.0.0",
-		"ghost-api": "v3"
+        "ghost": ">=5.0.0"
     },
     "license": "MIT",
     "author": {


### PR DESCRIPTION
### Description
Bump package version to `v3.0.0`

### Changes
- it's a major since we broke compatibilty with ghost pre v5
- bump `ghost` engine version number
- remove useless `ghost-api` from engines (inspired by https://github.com/TryGhost/Casper/blob/e2096ee731d071d9a32b4e0fab84272b14ba7203/package.json)